### PR TITLE
Mop up data left in __buffer if have a following ignoarable line or EOF.

### DIFF
--- a/lib/Config/INI/Reader/Multiline.pm
+++ b/lib/Config/INI/Reader/Multiline.pm
@@ -21,6 +21,34 @@ sub handle_unparsed_line {
     return $self->SUPER::handle_unparsed_line( $line, $handle );
 }
 
+
+sub can_ignore {
+    my ( $self, $line, $handle ) = @_;
+    if ( $line =~ /\A\s*(?:;|$)/ ) {
+
+        # If there is stuff left in buffer we need to see if it's name value pair.
+        if ( exists $self->{__buffer} ) {
+            if ( my ( $name, $value ) = $self->parse_value_assignment('') ) {
+                $self->set_value( $name, $value );
+            }
+        }
+        return 1;
+    }
+    return 0;
+
+}
+
+sub finalize {
+    my ($self) = @_;
+    return if !$self->{__buffer};
+
+    # If there is stuff left in buffer we need to see if it's name value pair.
+    if ( my ( $name, $value ) = $self->parse_value_assignment('') ) {
+        $self->set_value( $name, $value );
+    }
+
+}
+  
 1;
 
 __END__

--- a/t/comment.ini
+++ b/t/comment.ini
@@ -1,0 +1,9 @@
+[section1]
+        name1 = value1    \
+            extravalue1
+        name2 = value2 \
+;           commentedoutvalue2          
+
+[section2 ]
+; possibly deleted extra value
+    name3 = value3 \

--- a/t/comment.t
+++ b/t/comment.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Config::INI::Reader::Multiline;
+use Config::INI::Reader;
+
+my %test = (
+    't/comment.ini' => {
+        'section1' => {
+            'name1' => 'value1 extravalue1',
+            'name2' => 'value2',
+        },
+        'section2' => {
+            'name3' => 'value3',
+        },
+    }
+);
+
+plan tests => scalar keys %test;
+
+for my $ini ( sort keys %test ) {
+    my $config = Config::INI::Reader::Multiline->read_file($ini);
+    # diag explain $config;
+    is_deeply( $config, $test{$ini}, $ini );
+}
+
+done_testing();


### PR DESCRIPTION
If an ignorable line or EOF is encountered we check `$self->{__buffer}` and create a name/value pair if possible.
Fixes #2